### PR TITLE
Brute Force Solution :

### DIFF
--- a/findMedianSortedArrays/findMedianSortedArrays.go
+++ b/findMedianSortedArrays/findMedianSortedArrays.go
@@ -1,0 +1,37 @@
+package findMedianSortedArrays
+
+func FindMedianSortedArrays(nums1 []int, nums2 []int) float64 {
+	medium := len(nums1) + len(nums2)
+
+	index1 := 0
+	index2 := 0
+	var temp []int
+
+
+	for i := 0; i <= medium/2; i ++ {
+		if index1+1 > len(nums1) {
+			temp = append(temp, nums2[index2:index2+ medium/2+1-i]...)
+			break
+		}
+
+		if index2+1 > len(nums2) {
+			temp = append(temp, nums1[index1:index1+ medium/2+1-i]...)
+			break
+		}
+
+		if nums1[index1] < nums2[index2] {
+			temp = append(temp, nums1[index1])
+			index1++
+		} else {
+			temp = append(temp, nums2[index2])
+			index2++
+		}
+
+	}
+
+	if medium%2 == 0 {
+		return (float64(temp[len(temp)-1])+float64(temp[len(temp)-2]))/2.0
+	}
+
+	return float64(temp[len(temp)-1])
+}

--- a/test/findMedianSortedArrays_test.go
+++ b/test/findMedianSortedArrays_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"github.com/magiconair/properties/assert"
+	"leetcode/findMedianSortedArrays"
+	"testing"
+)
+
+func TestFindMedianSortedArrays(t *testing.T) {
+	testData := []struct{
+		input []int
+		input2 []int
+		expected float64
+	}{
+		{[]int{1, 3}, []int{2}, 2.0},
+		{[]int{1, 2}, []int{3, 4}, 2.5},
+		{[]int{0, 0}, []int{0, 0}, 0},
+		{[]int{}, []int{1}, 1},
+		{[]int{2}, []int{}, 2},
+		{[]int{}, []int{2,3}, 2.5},
+	}
+
+	for _,td := range testData {
+		result := findMedianSortedArrays.FindMedianSortedArrays(td.input, td.input2)
+		assert.Equal(t, result, td.expected)
+	}
+}


### PR DESCRIPTION
There are two sorted arrays nums1 and nums2 of size m and n respectively.

Find the median of the two sorted arrays. The overall run time complexity should be O(log (m+n)).

You may assume nums1 and nums2 cannot be both empty.

Example 1:

nums1 = [1, 3]
nums2 = [2]

The median is 2.0
Example 2:

nums1 = [1, 2]
nums2 = [3, 4]

The median is (2 + 3)/2 = 2.5
