### PR TITLE
Sort & select start & end position

### DIFF
--- a/removeElement/removeElement.go
+++ b/removeElement/removeElement.go
@@ -1,0 +1,22 @@
+package removeElement
+
+import "sort"
+
+func RemoveElement(nums []int, val int) int {
+	sort.Ints(nums)
+	start := 0
+	end := -1
+
+	for i,v := range nums {
+		if v == val {
+			if start == 0 && end == -1 {
+				start = i
+			}
+			end = i
+		}
+	}
+
+	nums = append(nums[:start], nums[end+1:]...)
+
+	return len(nums)
+}

--- a/test/removeElement_test.go
+++ b/test/removeElement_test.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"github.com/magiconair/properties/assert"
+	"leetcode/removeElement"
+	"testing"
+)
+
+func TestRemoveElement(t *testing.T) {
+	testData := []struct{
+		input []int
+		target int
+		expected int
+	}{
+		{[]int{3,2,2,3}, 3, 2},
+		{[]int{0,1,2,2,3,0,4,2}, 2, 5},
+		{[]int{}, 0, 0},
+		{[]int{2}, 3, 1},
+	}
+
+	for _,td := range testData {
+		result := removeElement.RemoveElement(td.input, td.target)
+		assert.Equal(t, result, td.expected)
+	}
+}


### PR DESCRIPTION
Given an array nums and a value val, remove all instances of that value in-place and return the new length.

Do not allocate extra space for another array, you must do this by modifying the input array in-place with O(1) extra memory.

The order of elements can be changed. It doesn't matter what you leave beyond the new length.

Example 1:

Given nums = [3,2,2,3], val = 3,

Your function should return length = 2, with the first two elements of nums being 2.

It doesn't matter what you leave beyond the returned length.
Example 2:

Given nums = [0,1,2,2,3,0,4,2], val = 2,

Your function should return length = 5, with the first five elements of nums containing 0, 1, 3, 0, and 4.

Note that the order of those five elements can be arbitrary.

It doesn't matter what values are set beyond the returned length.
Clarification:

Confused why the returned value is an integer but your answer is an array?

Note that the input array is passed in by reference, which means modification to the input array will be known to the caller as well.
